### PR TITLE
cancel drag when not full height

### DIFF
--- a/lib/scrollable_bottom_sheet.dart
+++ b/lib/scrollable_bottom_sheet.dart
@@ -293,6 +293,8 @@ class _ScrollableBottomSheetState extends State<ScrollableBottomSheet>
                 }
                 if (_currentHeight >= _fullHeight) {
                   _drag?.end(details);
+                } else {
+                  _drag?.cancel();
                 }
               },
               onVerticalDragDown: (DragDownDetails details) {


### PR DESCRIPTION
Input such as a button tap does not work on first click after the user drags. The reason for that is because the drag is still active. We need to `cancel` or `end` the drag within every `onVerticalDragEnd` execution.